### PR TITLE
do not install "install/libtarget_sys.so"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,4 +122,4 @@ endif()
 file(COPY include/target-sys DESTINATION ${CMAKE_INSTALL_PREFIX}/include
   PATTERN "*.am" EXCLUDE)
 
-install(TARGETS target_sys DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(TARGETS target_sys DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
Currently `libtarget_sys.so` is installed in two locations:

- `install/lib/libtarget_sys.so` - correct
- `install/libtarget_sys.so` - incorrect
