### PR TITLE
coverity issue 

### DIFF
--- a/src/bf_sal/linux_usr/bf_sys_dma_hugepages.c
+++ b/src/bf_sal/linux_usr/bf_sys_dma_hugepages.c
@@ -127,8 +127,8 @@ bf_phys_addr_t bf_mem_virt2phy(const void *virtaddr) {
     close(fd);
     return BF_INVALID_PHY_ADDR;
   }
-
-  if (read(fd, &page, sizeof(uint64_t)) < 0) {
+  uint64_t size_f = read(fd, &page, sizeof(uint64_t); 
+  if (size_f != sizeof(uint64_t) {
     printf("%s(): cannot read /proc/self/pagemap: %s\n", __func__,
            strerror(errno));
     close(fd);


### PR DESCRIPTION
Resolved:
 Ignoring number of bytes read (CHECKED_RETURN)
 check_return: read(int, void *, size_t) returns the number of bytes read, but it is ignored.
