### PR TITLE
Add 'const' qualifier to bf_sys_log parameters

### DIFF
--- a/include/target-sys/bf_sal/bf_sys_log.h
+++ b/include/target-sys/bf_sal/bf_sys_log.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright(c) 2021 Intel Corporation.
+ * Copyright(c) 2021-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this software except as stipulated in the License.
@@ -106,7 +106,7 @@ extern "C" {
  * @return
  *  0 on Sucess, -1 on error
  */
-int bf_sys_log_init(void *arg1, void *arg2, void *arg3);
+int bf_sys_log_init(const void *arg1, const void *arg2, const void *arg3);
 
 /**
  * close bf_sys_log subsystem

--- a/src/bf_sal/linux_usr/bf_sys_log.c
+++ b/src/bf_sal/linux_usr/bf_sys_log.c
@@ -157,7 +157,7 @@ static int bf_sys_zlog_init(const char *arg1) {
   return 0;
 }
 
-int bf_sys_log_zlog_reconfig(char *cfg_file_name) {
+int bf_sys_log_zlog_reconfig(const char *cfg_file_name) {
   if (zlog_reload(cfg_file_name) != 0) {
     printf("error initializing bf_sys_log\n");
     return -1;
@@ -165,7 +165,7 @@ int bf_sys_log_zlog_reconfig(char *cfg_file_name) {
   return 0;
 }
 
-zlog_category_t *bf_sys_log_get_cat(char *category_name) {
+zlog_category_t *bf_sys_log_get_cat(const char *category_name) {
   return (zlog_get_category(category_name));
 }
 
@@ -189,7 +189,7 @@ static int bf_sys_trace_init(int default_level) {
 /* arg1 - Path to logging config file.
  * arg2 - Trace level.
  * arg3 - Trace size. */
-int bf_sys_log_init(void *arg1, void *arg2, void *arg3) {
+int bf_sys_log_init(const void *arg1, const void *arg2, const void *arg3) {
   int err;
   (void)arg3;
 


### PR DESCRIPTION
Declared the parameters to bf_sys_log_init() to be const pointers, so you can pass a literal string to them without getting compile errors. (Plus, it's good programming practice to declare all input pointer parameters as pointers to const, making their values explicitly immutable.)

Did the same for several other functions that aren't part of the external interface.